### PR TITLE
Fixed generated widget attr code 

### DIFF
--- a/django_filepicker/forms.py
+++ b/django_filepicker/forms.py
@@ -48,10 +48,10 @@ class FPFieldMixin():
                 }
 
         if self.services:
-            attrs['data-fp-option-services'] = self.services
+            attrs['data-fp-services'] = self.services
 
         if self.additional_params:
-            attrs = dict(list(attrs.items()) + list(self.additional_params.items()))            
+            attrs = dict(list(attrs.items()) + list(self.additional_params.items()))
 
         return attrs
 


### PR DESCRIPTION
Fixed generated widget attr code to allow for specific services selection. Change from `data-fp-option-services` to `data-fp-services`.
